### PR TITLE
Update warnings-ng to 11.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
             <artifactId>json</artifactId>
             <version>20240303</version>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.12</version>
+        </dependency>
 
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>io.jenkins.plugins</groupId>
             <artifactId>warnings-ng</artifactId>
-            <version>10.7.0</version>
+            <version>11.2.2</version>
         </dependency>
         <!-- Upper bound dependency -->
         <dependency>


### PR DESCRIPTION
This needs an additional upper bound dependency.

#211, #215