### PR TITLE
Update to Jenkins 2.462.3 LTS and update BOM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <packaging>hpi</packaging>
 
     <properties>
-        <jenkins.version>2.462.1</jenkins.version>
+        <jenkins.version>2.462.3</jenkins.version>
     </properties>
 
     <name>Pipeline Extensions</name>
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.462.x</artifactId>
-                <version>3387.v0f2773fa_3200</version>
+                <version>3435.v238d66a_043fb_</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>


### PR DESCRIPTION
Jenkins 2.462.3 is required by plugins already.