### PR TITLE
Deprecate CVE Scanner

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,4 +43,8 @@ Users with permission `app/administer` have access to those parameter types and 
 
 ## CVE Summary parser
 
+### Deprecation
+
+*The CVE summary parser is deprecated and will be removed in v0.6.0; it's available as `yoctoScanner()` in [Warnings NG](https://github.com/jenkinsci/warnings-ng-plugin) now.*
+
 Extension to [Warnings NG](https://github.com/jenkinsci/warnings-ng-plugin) which supports parsing of *CVE summary* JSON files.

--- a/src/main/java/io/jhnc/jenkins/plugins/pipeline/analysis/cve/CveScanParser.java
+++ b/src/main/java/io/jhnc/jenkins/plugins/pipeline/analysis/cve/CveScanParser.java
@@ -29,6 +29,10 @@ import edu.hm.hafner.analysis.Report;
 import edu.hm.hafner.analysis.parser.JsonIssueParser;
 import org.json.JSONObject;
 
+/**
+ * @deprecated Replaced by {@code yoctoScanner()} of <i>warnings-ng</i>; will be removed in v0.6.0
+ */
+@Deprecated(forRemoval = true, since = "0.5.2")
 public class CveScanParser extends JsonIssueParser {
     @Override
     protected void parseJsonObject(Report report, JSONObject jsonReport, IssueBuilder issueBuilder) {

--- a/src/main/java/io/jhnc/jenkins/plugins/pipeline/analysis/cve/CveScanner.java
+++ b/src/main/java/io/jhnc/jenkins/plugins/pipeline/analysis/cve/CveScanner.java
@@ -30,6 +30,10 @@ import hudson.Extension;
 import io.jenkins.plugins.analysis.core.model.ReportScanningTool;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+/**
+ * @deprecated Replaced by {@code yoctoScanner()} of <i>warnings-ng</i>; will be removed in v0.6.0
+ */
+@Deprecated(forRemoval = true, since = "0.5.2")
 public class CveScanner extends ReportScanningTool {
     static final String ID = "cve-scanner";
 

--- a/src/main/java/io/jhnc/jenkins/plugins/pipeline/analysis/cve/CveScore.java
+++ b/src/main/java/io/jhnc/jenkins/plugins/pipeline/analysis/cve/CveScore.java
@@ -27,6 +27,10 @@ package io.jhnc.jenkins.plugins.pipeline.analysis.cve;
 import edu.hm.hafner.analysis.Severity;
 import edu.umd.cs.findbugs.annotations.NonNull;
 
+/**
+ * @deprecated Replaced by {@code yoctoScanner()} of <i>warnings-ng</i>; will be removed in v0.6.0
+ */
+@Deprecated(forRemoval = true, since = "0.5.2")
 public class CveScore {
     private final String scoreV3;
     private final String scoreV2;


### PR DESCRIPTION
Deprecate CVE Scanner in favour of the now available implementation of warnings-ng (related #207).